### PR TITLE
build: slim down Bevy dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,23 @@ repository = "https://github.com/forbjok/bevy_simple_tilemap.git"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.9.0"
 bitflags = "1.3.2"
 bytemuck = "1.12.3"
+
+[dependencies.bevy]
+version = "0.9.0"
+default-features = false
+features = [
+  "bevy_render",
+  "bevy_core_pipeline",
+  "bevy_sprite",
+  "bevy_asset",
+]
+
+[dev-dependencies.bevy]
+version = "0.9.0"
+default-features = false
+features = ["x11", "png"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rayon = "1.5.3"


### PR DESCRIPTION
Removes any bevy dependencies not needed to compile the crate.

This prevents pulling in things like gamepad handling or 3D rendering that some games don't need.