### PR TITLE
fix: don't panic when attempting to draw with uninitialized vertex buffer.

### DIFF
--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -95,7 +95,9 @@ impl EntityRenderCommand for SetVertexBuffer {
         let tilemap_batch = query_batch.get(item).unwrap();
         let chunk_meta = tilemap_meta.into_inner().chunks.get(&tilemap_batch.chunk_key).unwrap();
 
-        pass.set_vertex_buffer(0, chunk_meta.vertices.buffer().unwrap().slice(..));
+        if let Some(buffer) = chunk_meta.vertices.buffer() {
+            pass.set_vertex_buffer(0, buffer.slice(..));
+        }
 
         RenderCommandResult::Success
     }


### PR DESCRIPTION
Fixes: #11.
_ _ _

I'm not sure exactly what scenario caused the vertex buffer to be un-initialized, but this fixes the crash described in #11 for me.