### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ fn setup(
     };
 
     // Spawn tilemap
-    commands.spawn_bundle(tilemap_bundle);
+    commands.spawn(tilemap_bundle);
 }
 ```
 


### PR DESCRIPTION
`spawn_batch` was removed in Bevy 0.9